### PR TITLE
Upgrade to .NET 9 and refactor builder interfaces

### DIFF
--- a/AspireStarterProjectWithEfSqlServer/AspireApp/AspireApp.AppHost/Program.cs
+++ b/AspireStarterProjectWithEfSqlServer/AspireApp/AspireApp.AppHost/Program.cs
@@ -1,10 +1,10 @@
-var builder = DistributedApplication.CreateBuilder(args);
+IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder(args);
 
-var password = builder.AddParameter("password", secret: true);
-var sql = builder.AddSqlServer("sql", password);
-var sqldb = sql.AddDatabase("sqldb");
+IResourceBuilder<ParameterResource> password = builder.AddParameter("sql-password", secret: true);
+IResourceBuilder<SqlServerServerResource> sql = builder.AddSqlServer("sql", password);
+IResourceBuilder<SqlServerDatabaseResource> sqldb = sql.AddDatabase("sqldb");
 
-var apiService = builder
+IResourceBuilder<ProjectResource> apiService = builder
     .AddProject<Projects.AspireApp_ApiService>("apiservice")
     .WithReference(sqldb);
 

--- a/AspireStarterProjectWithEfSqlServer/AspireApp/AspireApp.AppHost/appsettings.json
+++ b/AspireStarterProjectWithEfSqlServer/AspireApp/AspireApp.AppHost/appsettings.json
@@ -7,6 +7,6 @@
     }
   },
   "Parameters": {
-    "password": "P@$$w0rd"
+    "sql-password": ""
   }
 }

--- a/AspireWithKeycloakContainer/AspireApp/AspireApp.ApiService/AspireApp.ApiService.csproj
+++ b/AspireWithKeycloakContainer/AspireApp/AspireApp.ApiService/AspireApp.ApiService.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AspireWithKeycloakContainer/AspireApp/AspireApp.AppHost/AspireApp.AppHost.csproj
+++ b/AspireWithKeycloakContainer/AspireApp/AspireApp.AppHost/AspireApp.AppHost.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
 
-  <PropertyGroup>
+	<PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
@@ -15,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/AspireWithKeycloakContainer/AspireApp/AspireApp.ServiceDefaults/AspireApp.ServiceDefaults.csproj
+++ b/AspireWithKeycloakContainer/AspireApp/AspireApp.ServiceDefaults/AspireApp.ServiceDefaults.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
@@ -10,13 +10,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.9.1" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
   </ItemGroup>
 
 </Project>

--- a/AspireWithKeycloakContainer/AspireApp/AspireApp.Web/AspireApp.Web.csproj
+++ b/AspireWithKeycloakContainer/AspireApp/AspireApp.Web/AspireApp.Web.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated `Program.cs` to use specific interfaces for builders, renaming the SQL password parameter to "sql-password". Modified `appsettings.json` to reflect this change.

Upgraded target frameworks to `net9.0` in `AspireApp.ApiService.csproj`, `AspireApp.AppHost.csproj`, `AspireApp.ServiceDefaults.csproj`, and `AspireApp.Web.csproj`.

Updated package versions for `Microsoft.AspNetCore.Authentication.JwtBearer`, `Microsoft.AspNetCore.Authentication.OpenIdConnect`, and various OpenTelemetry packages to their latest compatible versions.